### PR TITLE
(feat) adding watchdog and MCUBoot support to ZMK app

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -87,6 +87,7 @@ target_sources_ifdef(CONFIG_USB_DEVICE_STACK app PRIVATE src/usb.c)
 target_sources_ifdef(CONFIG_ZMK_USB app PRIVATE src/usb_hid.c)
 target_sources_ifdef(CONFIG_ZMK_RGB_UNDERGLOW app PRIVATE src/rgb_underglow.c)
 target_sources_ifdef(CONFIG_ZMK_BACKLIGHT app PRIVATE src/backlight.c)
+target_sources_ifdef(CONFIG_ZMK_WATCHDOG app PRIVATE src/watchdog.c)
 target_sources(app PRIVATE src/workqueue.c)
 target_sources(app PRIVATE src/main.c)
 

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -562,6 +562,29 @@ choice CBPRINTF_IMPLEMENTATION
 
 endchoice
 
+config ZMK_WATCHDOG
+    bool "Enable support for watchdog timer"
+    select WATCHDOG
+    help
+      Enable hardware watchdog for ZMK. This will reset the keyboard if the
+      application crashes within the timeout range specified by the minimum
+      and maximum timeout intervals
+
+if ZMK_WATCHDOG
+
+config ZMK_WATCHDOG_TIMEOUT
+    int "Watchdog timeout in milliseconds"
+    default 5000
+    help
+      Watchdog timeout that will be set. If the firmware does not service
+      the watchdog within this timeout, the keyboard will reset.
+
+config ZMK_WATCHDOG_INIT_PRIORITY
+    int "Watchdog Init Priority"
+    default 0
+
+endif # ZMK_WATCHDOG
+
 module = ZMK
 module-str = zmk
 source "subsys/logging/Kconfig.template.log_config"

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -8,6 +8,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/settings/settings.h>
+#include <zephyr/dfu/mcuboot.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(zmk, CONFIG_ZMK_LOG_LEVEL);
@@ -27,4 +28,8 @@ void main(void) {
 #ifdef CONFIG_ZMK_DISPLAY
     zmk_display_init();
 #endif /* CONFIG_ZMK_DISPLAY */
+#ifdef CONFIG_MCUBOOT_IMG_MANAGER
+    /* Mark image as confirmed */
+    boot_write_img_confirmed();
+#endif /* CONFIG_BOOTLOADER_MCUBOOT */
 }

--- a/app/src/watchdog.c
+++ b/app/src/watchdog.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zephyr/drivers/watchdog.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+const struct device *wdog = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zmk_watchdog));
+
+const struct wdt_timeout_cfg wdt_config = {
+    /* Reset SOC when timer expires */
+    .flags = WDT_FLAG_RESET_SOC,
+
+    /* Setup max only, we do not want watchdog in windowed mode */
+    .window.max = CONFIG_ZMK_WATCHDOG_TIMEOUT,
+};
+
+static int wdog_channel_id;
+
+/* Feed function. Runs on a kernel timer. */
+static void zmk_watchdog_feed(struct k_timer *timer)
+{
+
+    (void)wdt_feed(wdog, wdog_channel_id);
+    /* Feed watchdog */
+    LOG_DBG("Fed hardware watchdog");
+}
+
+/* Define kernel timer */
+K_TIMER_DEFINE(watchdog_timer, zmk_watchdog_feed, NULL);
+
+int zmk_watchdog_init(const struct device *dev)
+{
+    int ret;
+
+    if (!device_is_ready(wdog)) {
+    	LOG_ERR("Watchdog not ready");
+    	return -ENODEV;
+    }
+
+    ret = wdt_install_timeout(wdog, &wdt_config);
+    if (ret < 0) {
+        LOG_ERR("Could not install watchdog timeout (%d)", ret);
+        return ret;
+    }
+    /* Save channel ID if we installed timeout successfully */
+    wdog_channel_id = ret;
+    /* Setup WDT. After this point we must call wdt_feed periodically */
+    ret = wdt_setup(wdog, WDT_OPT_PAUSE_HALTED_BY_DBG);
+    if (ret < 0) {
+        LOG_ERR("Could not setup watchdog timeout (%d)", ret);
+    }
+
+    /* Start watchdog feed timer, with period shorter than
+     * the watchdog timeout
+     */
+    k_timer_start(&watchdog_timer,
+                  K_MSEC(CONFIG_ZMK_WATCHDOG_TIMEOUT - 100U),
+                  K_MSEC(CONFIG_ZMK_WATCHDOG_TIMEOUT - 100U));
+    return ret;
+}
+
+
+SYS_INIT(zmk_watchdog_init, APPLICATION, CONFIG_ZMK_WATCHDOG_INIT_PRIORITY);


### PR DESCRIPTION
Adding support for keyboard watchdog and MCUBoot support to the ZMK application

Keyboard watchdog is very simplistic, and currently only will catch issues where the firmware enters a kernel panic

Note- MCUBoot support requires that `CONFIG_IMG_MANAGER` be enabled